### PR TITLE
Remove floating scroll when attached element is removed

### DIFF
--- a/src/floatingscroll/jquery.floatingscroll.js
+++ b/src/floatingscroll/jquery.floatingscroll.js
@@ -54,7 +54,7 @@ $.extend(FScroll.prototype, {
 	initScroll: function () {
 		var flscroll = $("<div class='fl-scrolls'></div>");
 		$("<div></div>").appendTo(flscroll).css({width: this.cont.block.scrollWidth + "px"});
-		return flscroll.appendTo("body");
+		return flscroll.appendTo(this.cont.block);
 	},
 
 	checkVisibility: function () {


### PR DESCRIPTION
In my project I have a table that requires floatingscroll. This table can be removed and re-created (according to user). This is when I noticed that the scrollbar will stay there, and gets duplicated when the table is re-created.

Fixed that by appending the scrollbar element to the attached element (the table) instead of `body`, so now when the attached element is removed the scrollbar will be removed. Otherwise the floating bar would stay, or worst, get duplicated when the parent element is re-created (and re-attached).

There is still a leak problem with the `$(window).bind`, which will stay bound forever, and leak on re-attaches. Tried to think of a way to expose the FScroll object outside and then give it a destructor (which will be the user's responsibility to invoke), or maybe keep it somewhere and have a `detachScroll` method on `$.fn`. Any ideas?
